### PR TITLE
Make the shell script fasters + shellcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     privileged: true
     ports:
       - 2375:2375
+      - 80:80
+      - 443:443
+      - 8080:8080
     networks:
       - swarm
   manager:

--- a/script/deploy-image.sh
+++ b/script/deploy-image.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-set -eu
+set -eu -o pipefail
 
 for CID in $(docker ps -f name=swarm -q); do
-  docker cp ${1} ${CID}:/img.tar
-  docker exec -ti ${CID} docker load -i /img.tar
+  docker cp "${1}" "${CID}:/img.tar" &
 done
+
+wait
+
+for CID in $(docker ps -f name=swarm -q); do
+  docker exec -t "${CID}" docker load -i "/img.tar" &
+done
+
+wait

--- a/script/init-cluster.sh
+++ b/script/init-cluster.sh
@@ -3,11 +3,11 @@
 set -eu
 
 function control_docker() {
-  DOCKER_HOST=tcp://localhost:2375 docker $@
+  DOCKER_HOST=tcp://localhost:2375 docker "$@"
 }
 
 function docker_exec() {
-  docker exec -ti $@
+  docker exec -t "$@"
 }
 
 echo "Initializing the swarm..."
@@ -20,14 +20,18 @@ MANAGER_IP=$(control_docker info -f "{{.Swarm.NodeAddr}}")
 echo "Setuping masters..."
 
 for CID in $(docker ps -f name=manager -q); do
-  docker_exec ${CID} docker swarm join --token ${MANAGER_JOIN_TOKEN} ${MANAGER_IP}:2377
+  docker_exec "${CID}" docker swarm join --token "${MANAGER_JOIN_TOKEN}" "${MANAGER_IP}:2377" &
 done
+
+wait
 
 echo "Setuping workers..."
 
 for CID in $(docker ps -f name=worker -q); do
-  docker_exec ${CID} docker swarm join --token ${WORKER_JOIN_TOKEN} ${MANAGER_IP}:2377
+  docker_exec "${CID}" docker swarm join --token "${WORKER_JOIN_TOKEN}" "${MANAGER_IP}:2377" &
 done
+
+wait
 
 echo "All is good, enjoy your new swarm cluster !"
 


### PR DESCRIPTION
This PR introduces the following changes:

- Applying shell check to the shell scripts
- Remote the `-i` flags for the `docker exec` commands, to handle script (non interactive) cases
- Make the execution of the scripts faster, by parallelizing the costly operation (`docker cp`, `docker load`, etc.).
- Open 3 common ports to reach the applications deployed inside the cluster